### PR TITLE
support extra_params

### DIFF
--- a/collabora-code/config.yaml
+++ b/collabora-code/config.yaml
@@ -32,6 +32,7 @@ options:
   dont_gen_ssl_cert: false
   username: ""
   password: ""
+  extra_params: "--o:logging.level=information --o:logging.color=false"
 
 schema:
   username: str

--- a/collabora-code/scripts/start-collabora-online.sh
+++ b/collabora-code/scripts/start-collabora-online.sh
@@ -69,4 +69,6 @@ bashio::log.info "done."
 
 # Start coolwsd
 bashio::log.info "Starting coolwsd..."
+# explicitly allow spaces to separate arguments
+# shellcheck disable=SC2086
 exec /usr/bin/coolwsd --version --use-env-vars "${cert_params:-}" --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:stop_on_config_change=true ${extra_params:-} "$@"

--- a/collabora-code/scripts/start-collabora-online.sh
+++ b/collabora-code/scripts/start-collabora-online.sh
@@ -69,4 +69,4 @@ bashio::log.info "done."
 
 # Start coolwsd
 bashio::log.info "Starting coolwsd..."
-exec /usr/bin/coolwsd --version --use-env-vars "${cert_params:-}" --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:logging.color=false --o:stop_on_config_change=true "${extra_params:-}" "$@"
+exec /usr/bin/coolwsd --version --use-env-vars "${cert_params:-}" --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:stop_on_config_change=true ${extra_params:-} "$@"


### PR DESCRIPTION
# Proposed Changes

> Support configuration of additional command line arguments.
> e.g. logging: https://sdk.collaboraonline.com/docs/installation/Configuration.html#logging

## Related Issues

> none

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
