### PR TITLE
set default add-on configuration

### DIFF
--- a/collabora-code/config.yaml
+++ b/collabora-code/config.yaml
@@ -32,7 +32,7 @@ options:
   dont_gen_ssl_cert: false
   username: ""
   password: ""
-  extra_params: "--o:logging.level=information --o:logging.color=false"
+  extra_params: "--o:logging.level=information --o:logging.color=false --o:ssl.enable=false --o:ssl.termination=true"
 
 schema:
   username: str


### PR DESCRIPTION
Set needed configuration options, to use CODE behind a reverse proxy doing SSL termination, as default.